### PR TITLE
Removed unnecessary scoped attribute in switch-button’s styling

### DIFF
--- a/packages/switch-button/src/index.vue
+++ b/packages/switch-button/src/index.vue
@@ -55,7 +55,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 .t-ui-switch-button__button {
 	-webkit-appearance: none;
 	padding: 0;


### PR DESCRIPTION
### What has been added
A fix for #64 
