### PR TITLE
Fixes tournant/notification README.md 

### DIFF
--- a/packages/notification/README.md
+++ b/packages/notification/README.md
@@ -1,6 +1,6 @@
-# @tournant/alert
+# @tournant/notification
 
-Notification messages that can be picked up by screenreaders. Implements the [status role](https://www.w3.org/TR/wai-aria-1.1/#status) by default. But can also be used an [alert widget](https://www.w3.org/TR/wai-aria-1.1/#alert).
+Notification messages that can be picked up by screenreaders. Implements the [status role](https://www.w3.org/TR/wai-aria-1.1/#status) by default. But can also be used as an [alert widget](https://www.w3.org/TR/wai-aria-1.1/#alert).
 
 ## Installation
 


### PR DESCRIPTION
### What has been added

A fix to the documentation of @tournant/notification. On npm it says @tournant/alert even though ot's called @tournant/notification everywhere ... also inside the title tag. This was super confusing to me when looking up the component on npm. 

### How can this be tested

No testing needed I guess

### In which screen readers have these additions been tested

- [ ] NVDA
- [ ] JAWS
- [ ] VoiceOver
- [ ] TalkBack

### In which browsers have these additions been tested

#### Mobile

- [ ] Firefox
- [ ] Chrome (Android)
- [ ] Safari (iOS)
- [ ] Samsung Internet

#### Desktop

- [ ] Firefox (recent)
- [ ] Edge (recent)
- [ ] Chrome (recent)
- [ ] Safari (recent)

### Additonal remarks