### PR TITLE
Fix @tournant/notification description on the website

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -119,7 +119,7 @@
 								<span style="font-weight: 300;">@tournant/</span>notification
 							</h3>
 							<p>
-								A trail of links to let users find their place within a website.
+								Notification messages that can be picked up by screenreaders and that can also be used as an alert widget.
 							</p>
 							<a href="https://www.npmjs.com/package/@tournant/notification" class="component-card__link"><span
 									class="sr-only">notification</span> package link</a>


### PR DESCRIPTION
### What has been added

The description of the notification component on the torunant ui website is replaced with a slightly shorter version of the description of its README.md

### How can this be tested

No testing required - I guess.

### In which screen readers have these additions been tested

- [ ] NVDA
- [ ] JAWS
- [ ] VoiceOver
- [ ] TalkBack

### In which browsers have these additions been tested

#### Mobile

- [ ] Firefox
- [ ] Chrome (Android)
- [ ] Safari (iOS)
- [ ] Samsung Internet

#### Desktop

- [ ] Firefox (recent)
- [ ] Edge (recent)
- [ ] Chrome (recent)
- [ ] Safari (recent)

### Additonal remarks
